### PR TITLE
option X-Forwarded-For

### DIFF
--- a/Istex.txt
+++ b/Istex.txt
@@ -1,7 +1,10 @@
-# Plateforme : Istex
-# Date configuration validée : 12/2014
+# API Istex
+# Date configuration validée : 02/2015
+Option NoX-Forwarded-For
 
 Title Plateforme Istex (API)
 URL   http://api.istex.fr/
 HJ    https://api.istex.fr/
 DJ    istex.fr
+
+Option X-Forwarded-For


### PR DESCRIPTION
il est nécessaire de désactiver l'option X-Forwarded-For pour que ca fonctionne également en interne a l'Inist (pour les ezproxy hors cnrs cela ne devrait pas changer)
