### PR TITLE
Create Lamyline.txt

### DIFF
--- a/Lamyline.txt
+++ b/Lamyline.txt
@@ -1,0 +1,15 @@
+# Plateforme : Lamyline
+# Date configuration validée : 09/2016
+# Remplacer ------ dans l'URL par le token fourni par Lamyline et spécifique à chaque établissement
+
+Title Lamyline
+Option NoX-Forwarded-For
+URL   http://lamyline.lamy.fr/Content/Inicio.aspx?DATA=-----------
+DJ    lamy.fr
+DJ    lamyline.fr
+DJ    lamyline.lamy.fr
+HJ    lamy.fr
+HJ    lamyline.lamy.fr
+DJ    mediaswk.com
+DJ    jsdelivr.net
+DJ    wkcols.com

--- a/Lamyline.txt
+++ b/Lamyline.txt
@@ -1,6 +1,7 @@
 # Plateforme : Lamyline
 # Date configuration validée : 09/2016
 # Remplacer ------ dans l'URL par le token fourni par Lamyline et spécifique à chaque établissement
+# À supprimer le jour où OCLC aura mis à jour ton stanza : https://www.oclc.org/support/services/ezproxy/documentation/db/lamyline.en.html
 
 Title Lamyline
 Option NoX-Forwarded-For


### PR DESCRIPTION
La stanza proposée par OCLC https://www.oclc.org/support/services/ezproxy/documentation/db/lamyline.en.html ne fonctionne pas pour tous les établissements sur la nouvelle plateforme. Celle-ci a été fournie par Lamyline suite à divers tests avec plusieurs établissements de l'ESR français.