### PR TITLE
Update techniques de l'ingénieur

### DIFF
--- a/Techniques de l'ingénieur.txt
+++ b/Techniques de l'ingénieur.txt
@@ -3,7 +3,7 @@
 
 Title Techniques de l'Ingénieur
 URL http://www.techniques-ingenieur.fr
-DJ techniques-ingenieur.fr
+DJ www.techniques-ingenieur.fr
 DJ weka.fr
 RedirectSafe cdn.techniques-ingenieur.fr
 Find resourceUrl=http://


### PR DESCRIPTION
La plateforme utilise des polices chargées par bootstrap qui ne sont pas chargées lorsque cdn.techniques-ingenieur.fr est proxyfié or DJ techniques-ingenieur.fr prend le pas sur RedirectSafe cdn.techniques-ingenieur.fr, probablement parce qu'il est au niveau domaine. en ajoutant "www" à DJ, cela fonctionne avec notre instance d'EZProxy